### PR TITLE
fix: ensuring multimodal input's height doesn't shrink when inputting

### DIFF
--- a/src/components/core/multimodal-input.tsx
+++ b/src/components/core/multimodal-input.tsx
@@ -61,7 +61,8 @@ function PureMultimodalInput({
   const adjustHeight = () => {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight + 2}px`;
+      const newHeight = Math.max(textareaRef.current.scrollHeight + 2, 98);
+      textareaRef.current.style.height = `${newHeight}px`;
     }
   };
 


### PR DESCRIPTION
### Changes Made
- Fixes #8 

Note: 
- There was just an issue with the default height being larger than the auto height when inputting in the multimodal input.